### PR TITLE
fix: cli template creates binpath without --binary flag

### DIFF
--- a/cmd/gowncli/cmd/template.go
+++ b/cmd/gowncli/cmd/template.go
@@ -63,10 +63,15 @@ func NewTemplateCmd(version, module string) *cobra.Command {
 				Module:      module,
 				ProjectName: name,
 				Version:     version,
-				BinPath:     path.Join(exploitDir, binPath),
 				Host:        host,
 				Port:        port,
 			}
+
+			if binPath != "" {
+				params.BinPath = path.Join(exploitDir, binPath)
+				params.HasBinary = true
+			}
+
 			params.IsRemote = true
 			if host == "" && port == 0 {
 				params.IsRemote = false

--- a/cmd/gowncli/internal/tmpl/executor.go
+++ b/cmd/gowncli/internal/tmpl/executor.go
@@ -13,6 +13,7 @@ type TemplateParams struct {
 	ProjectName string
 	Version     string
 	BinPath     string
+	HasBinary   bool
 	Host        string
 	Port        uint16
 	IsRemote    bool

--- a/cmd/gowncli/internal/tmpl/templates/main.go.tmpl
+++ b/cmd/gowncli/internal/tmpl/templates/main.go.tmpl
@@ -1,14 +1,14 @@
 package main
 
 import (
-	{{- if not .BinPath }}
+	{{- if not .HasBinary }}
 	"encoding/binary"
 	{{ end }}
 	pwn "github.com/Jacute/gowntools"
 	"github.com/Jacute/gowntools/binutils"
 	"github.com/Jacute/gowntools/payload"
 )
-{{ if .BinPath }}
+{{ if .HasBinary }}
 const binpath string = "{{.BinPath}}"
 {{ end }}
 func main() {
@@ -19,7 +19,7 @@ func main() {
 	c := pwn.NewBinary(binpath)
 	defer c.Close()
 {{- end }}
-{{- if .BinPath }}
+{{- if .HasBinary }}
 	bin, err := binutils.AnalyzeBinary(binpath)
 	if err != nil {
 		panic(err)
@@ -32,7 +32,7 @@ func main() {
 {{ end }}
 	c.Interactive()
 }
-{{ if not .BinPath }}
+{{ if not .HasBinary }}
 func exploit(c pwn.Client) {
 	pb := payload.NewBuilder(binutils.ArchAmd64, binary.LittleEndian)
 {{- else }}


### PR DESCRIPTION
This PR fixes an issue where `gowncli template` would generate code containing `binpath` and `binInfo` even when the `--binary` flag was not provided.

Changes:
- Added `HasBinary` field to `TemplateParams`.
- Conditionally set `BinPath` and `HasBinary` in `NewTemplateCmd`.
- Updated `main.go.tmpl` to use `HasBinary` for conditional code generation.

Fixes #9